### PR TITLE
Add Bash Script for connecting to EC2 instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 
 # Created by https://www.toptal.com/developers/gitignore/api/linux,intellij
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,intellij
+#
+#
+
+## Our Added Stuff###
+# permission key files
+*.pem
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/bin/ec2.sh
+++ b/bin/ec2.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ssh -i "im_not_sure.pem" ubuntu@ec2-52-14-231-136.us-east-2.compute.amazonaws.com

--- a/bin/ec2.sh
+++ b/bin/ec2.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-ssh -i "im_not_sure.pem" ubuntu@ec2-52-14-231-136.us-east-2.compute.amazonaws.com
+ssh -i "~/.keys/im_not_sure.pem" ubuntu@ec2-52-14-231-136.us-east-2.compute.amazonaws.com


### PR DESCRIPTION
Ec2 Spun up on Aws-east-2. Server is updated, java installed. `/bin/` has a bash script for connecting to the server, will need permissions key file. 

Handles #5 